### PR TITLE
chore: fix commitlint

### DIFF
--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -1,7 +1,10 @@
+import type { UserConfig } from '@commitlint/types'
+import { RuleConfigSeverity } from '@commitlint/types'
+
 export default {
   extends: ['@commitlint/config-conventional'],
   rules: {
-    'body-max-line-length': 'off',
-    'footer-max-line-length': 'off',
+    'body-max-line-length': [RuleConfigSeverity.Disabled],
+    'footer-max-line-length': [RuleConfigSeverity.Disabled],
   },
-}
+} satisfies UserConfig

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "devDependencies": {
     "@commitlint/cli": "^19.1.0",
     "@commitlint/config-conventional": "^19.1.0",
+    "@commitlint/types": "^19.0.3",
     "@eslint/js": "^8.57.0",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/commit-analyzer": "^11.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
       '@commitlint/config-conventional':
         specifier: ^19.1.0
         version: 19.1.0
+      '@commitlint/types':
+        specifier: ^19.0.3
+        version: 19.0.3
       '@eslint/js':
         specifier: ^8.57.0
         version: 8.57.0


### PR DESCRIPTION
# Context

Commit lint was failing due to wrong configuration.

# Description

We use typed configuration to avoid wrong configuration.
