### PR TITLE
refactor: forbid console.log

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -21,6 +21,9 @@ export default tseslint.config(
         document: 'readonly',
       },
     },
+    rules: {
+      'no-console': ['error', { allow: ['warn', 'error'] }],
+    },
   },
   {
     files: ['**/*.{test,spec}.tsx?'],

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,6 +4,7 @@ import generator from './generator'
 import packageJson from '../package.json'
 
 if (['--version', '-v'].find(arg => process.argv.includes(arg))) {
+  // eslint-disable-next-line no-console
   console.log('v' + packageJson.version)
 } else {
   generator()

--- a/src/features/codeOfConduct/generateCodeOfConduct.ts
+++ b/src/features/codeOfConduct/generateCodeOfConduct.ts
@@ -7,6 +7,7 @@ import setVariable from '../../services/template/setVariable'
 import getCodeOfConductFilename from './utils/getCodeOfConductFilename'
 import printTerminal from '../../services/terminal/printTerminal'
 import getTemplatePath from '../../getTemplatePath'
+import printOutput from '../../services/terminal/printOutput'
 
 const generateCodeOfConduct = async () => {
   await context.init()
@@ -31,9 +32,7 @@ const generateCodeOfConduct = async () => {
 
     fs.writeFile(getCodeOfConductFilename(repositoryPath), templateContent)
 
-    console.log()
-    console.log(templateContent)
-
+    printOutput(templateContent)
     printTerminal('Code of conduct generated')
   } catch {
     // do nothing

--- a/src/features/contributing/generateContributing.ts
+++ b/src/features/contributing/generateContributing.ts
@@ -14,6 +14,7 @@ import * as packageManager from '../package/packageManager'
 import getContributingContentInReadme from './utils/getContributingContentInReadme'
 import getContributingFilename from './utils/getContributingFilename'
 import getTemplatePath from '../../getTemplatePath'
+import printOutput from '../../services/terminal/printOutput'
 
 const generateContributing = async () => {
   const templateFilename = getContributingFilename(getTemplatePath())
@@ -118,9 +119,7 @@ const generateContributing = async () => {
 
   await fs.writeFile(generatedContributingFilename, contributingContent)
 
-  console.log()
-  console.log(contributingContent)
-
+  printOutput(contributingContent)
   printTerminal('Contributing file generated')
 
   try {

--- a/src/features/license/generateLicense.ts
+++ b/src/features/license/generateLicense.ts
@@ -62,8 +62,7 @@ const generateLicense = async () => {
 
   const generatedLicenseFilename = getLicenseFilename(repositoryPath)
 
-  console.log()
-  console.log(licenseContent)
+  printTerminal(licenseContent)
 
   await fs.writeFile(generatedLicenseFilename, licenseContent)
   printTerminal(`License file "${generatedLicenseFilename}" generated`)

--- a/src/features/pullRequestTemplate/generatePullRequestTemplate.ts
+++ b/src/features/pullRequestTemplate/generatePullRequestTemplate.ts
@@ -24,7 +24,7 @@ const generatePullRequestTemplate = async () => {
   try {
     await fs.access(pullRequestTemplateFilename)
 
-    console.log('Pull request template already exists')
+    console.error('Pull request template already exists')
   } catch (error) {
     const templateFilename = getPullRequestTemplateFilename(TEMPLATES)
 

--- a/src/features/readme/generateReadme.ts
+++ b/src/features/readme/generateReadme.ts
@@ -13,6 +13,7 @@ import getContributingFilename from '../contributing/utils/getContributingFilena
 import getContributingContentInReadme from '../contributing/utils/getContributingContentInReadme'
 import getLicenseFilename from '../license/utils/getLicenseFilename'
 import getLicenseContentInReadme from '../license/utils/getLicenseContentInReadme'
+import printOutput from '../../services/terminal/printOutput'
 
 const generateReadme = async () => {
   await context.init()
@@ -124,10 +125,7 @@ ${installCommand} # Install dependencies${
 
   fs.writeFile(readmeFilename, readmeContent)
 
-  // eslint-disable-next-line no-console
-  console.log()
-  // eslint-disable-next-line no-console
-  console.log(readmeContent)
+  printOutput(readmeContent)
 
   if (created) {
     printTerminal('README file generated')

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -30,7 +30,7 @@ const generator = async () => {
   if (option in generators) {
     await generators[option]()
   } else {
-    console.log('Not implemented yet')
+    throw new Error('Not implemented yet')
   }
 }
 

--- a/src/services/terminal/printOutput.ts
+++ b/src/services/terminal/printOutput.ts
@@ -1,0 +1,8 @@
+const printOutput = (output: string) => {
+  // eslint-disable-next-line no-console
+  console.log()
+  // eslint-disable-next-line no-console
+  console.log(output)
+}
+
+export default printOutput

--- a/src/services/terminal/printTerminal.ts
+++ b/src/services/terminal/printTerminal.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-console
 const printTerminal = (message: string) => console.log(`✔ ${message}`)
 
 export default printTerminal


### PR DESCRIPTION
# Context

The `console.log` function was authorized in the code and it is not a good practice.

# Description

The eslint rule `no-console` was set to error while style accepting `console.error` and `console.warning`

Closes #16 

# Technical details

- chore: add eslint rules `no-console`
- refactor: remove most of the `console.log` uses
- refactor add function `printOutput`
