### PR TITLE
fix: contributing template not included in npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,6 @@
 src
 .github
 .prettierrc
-CONTRIBUTING.md
 jest.config.ts
 tsconfig.json
 node_modules


### PR DESCRIPTION
# Context

If I run the generator to get a contributing file, I get the error:

```bash
npx contributing-generator                                                                                                                                          

Need to install the following packages:
contributing-generator@1.14.2
Ok to proceed? (y) y
? What do you want to generate? contributing
node:internal/fs/promises:636
  return new FileHandle(await PromisePrototypeThen(
                        ^

Error: ENOENT: no such file or directory, open '/.../.npm/_npx/4b79217f5dc193eb/node_modules/contributing-generator/templates/CONTRIBUTING.md'
    at async open (node:internal/fs/promises:636:25)
    at async Object.readFile (node:internal/fs/promises:1246:14)
    at async Object.generateContributing [as contributing] (file:///.../.npm/_npx/4b79217f5dc193eb/node_modules/contributing-generator/dist/index.js:4806:29)
    at async generator (file:///.../.npm/_npx/4b79217f5dc193eb/node_modules/contributing-generator/dist/index.js:5233:9) {
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
  path: '/.../.npm/_npx/4b79217f5dc193eb/node_modules/contributing-generator/templates/CONTRIBUTING.md'
}

Node.js v20.13.1
```

# Description

It seems the file CONTRIBUTING is not included in the npm:

<img width="793" alt="image" src="https://github.com/friedrith/contributing-generator/assets/4005226/71c88abd-85f0-4817-833e-198bc0322ee6">

# Technical details (if applicable)

- keep all the contributing files